### PR TITLE
Feature: Add PD1 segment

### DIFF
--- a/lib/segments/pd1.rb
+++ b/lib/segments/pd1.rb
@@ -1,0 +1,31 @@
+# encoding: UTF-8
+class HL7::Message::Segment::PD1 < HL7::Message::Segment
+  weight 1
+  add_field :living_dependency
+  add_field :living_arrangement
+  add_field :patient_primary_facility
+  add_field :patient_primary_care_provider_name_and_id_no
+  add_field :student_indicator
+  add_field :handicap
+  add_field :living_will_code
+  add_field :organ_donor_code
+  add_field :separate_bill
+  add_field :duplicate_patient
+  add_field :publicity_code
+  add_field :protection_indicator
+  add_field :protection_indicator_effective_date do |value|
+    convert_to_ts(value)
+  end
+  add_field :place_of_worship
+  add_field :advance_directive_code
+  add_field :immunization_registry_status
+  add_field :immunization_registry_status_effective_date do |value|
+    convert_to_ts(value)
+  end
+  add_field :publicity_code_effective_date do |value|
+    convert_to_ts(value)
+  end
+  add_field :military_branch
+  add_field :military_rank
+  add_field :military_status
+end

--- a/spec/pd1_segment_spec.rb
+++ b/spec/pd1_segment_spec.rb
@@ -1,0 +1,36 @@
+# encoding: UTF-8
+require 'spec_helper'
+
+describe HL7::Message::Segment::PD1 do
+  context 'general' do
+    before :all do
+      @base = "PD1|S|A|SACRED HEART HOSPITAL|12345^DOCTORSON^DOC^M|F||Y|Y|Y||F|Y|201011110924-0700||DNR|A|201011110924-0700|201011110924-0700|USA|E1|ACT"
+    end
+
+    it "sets values correctly" do
+      pid = HL7::Message::Segment::PD1.new @base
+
+      expect(pid.living_dependency).to eq "S"
+      expect(pid.living_arrangement).to eq "A"
+      expect(pid.patient_primary_facility).to eq "SACRED HEART HOSPITAL"
+      expect(pid.patient_primary_care_provider_name_and_id_no).to eq "12345^DOCTORSON^DOC^M"
+      expect(pid.student_indicator).to eq "F"
+      expect(pid.handicap).to eq ""
+      expect(pid.living_will_code).to eq "Y"
+      expect(pid.organ_donor_code).to eq "Y"
+      expect(pid.separate_bill).to eq "Y"
+      expect(pid.duplicate_patient).to eq ""
+      expect(pid.publicity_code).to eq "F"
+      expect(pid.protection_indicator).to eq "Y"
+      expect(pid.protection_indicator_effective_date).to eq "201011110924-0700"
+      expect(pid.place_of_worship).to eq ""
+      expect(pid.advance_directive_code).to eq "DNR"
+      expect(pid.immunization_registry_status).to eq "A"
+      expect(pid.immunization_registry_status_effective_date).to eq "201011110924-0700"
+      expect(pid.publicity_code_effective_date).to eq "201011110924-0700"
+      expect(pid.military_branch).to eq "USA"
+      expect(pid.military_rank).to eq "E1"
+      expect(pid.military_status).to eq "ACT"
+    end
+  end
+end


### PR DESCRIPTION
Adds a parser for the HL7 PD1 segment. See other files in the lib/segments directory for an idea of how the parser works. See documentation here:
http://hl7-definition.caristix.com:9010/HL7%20v2.5/segment/PD1

To run tests:
```
git clone git@github.com:actmd/ruby-hl7.git
cd ruby-hl7
git checkout add-pd1-segment
bundle install
rspec
```